### PR TITLE
feat: support passing a sub-syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,13 @@ as follows:
   id: 'my-syntax',
 
   // Tagged templates to look for
-  tagNames: ['css']
+  tagNames: ['css'],
+
+  // Custom sub-parser
+  parser: lessSyntax.parse,
+
+  // Custom sub-stringifier _class_
+  stringifier: require('postcss-less/lib/LessStringifier.js')
 }
 ```
 
@@ -67,3 +73,29 @@ Two forms are supported:
 - Exact tag names (e.g. `['css']`)
 - Tag name prefixes (e.g. `['css.*']` would match `css.foo`, it is _not_ a
 RegExp)
+
+### Sub-syntax
+
+You may want to support a "syntax within a syntax". For example, LESS sources
+inside your JavaScript files.
+
+In order to do this, you must pass the syntax's parser and stringifier _class_
+in your options.
+
+For example:
+
+```ts
+createParser({
+  // ...
+  parser: require('postcss-less').parse,
+  stringifer: require('postcss-less/lib/LessStringifier.js')
+});
+```
+
+**Importantly, you must pass the _class_ of the stringifier rather than the
+stringify function.** This is so we can correctly extend it.
+
+Two common ones are (at time of writing this) located at:
+
+* SCSS - `postcss-scss/lib/scss-stringifier.js`
+* LESS - `postcss-less/lib/LessStringifier.js`

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,8 @@
         "mocha": "^10.2.0",
         "nyc": "^15.1.0",
         "postcss": "^8.4.20",
+        "postcss-less": "^6.0.0",
+        "postcss-scss": "^4.0.6",
         "prettier": "^2.8.1",
         "rimraf": "^3.0.2",
         "stylelint": "^14.16.0",
@@ -3512,6 +3514,18 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/postcss-less": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-less/-/postcss-less-6.0.0.tgz",
+      "integrity": "sha512-FPX16mQLyEjLzEuuJtxA8X3ejDLNGGEG503d2YGZR5Ask1SpDN8KmZUMpzCvyalWRywAn1n1VOA5dcqfCLo5rg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "postcss": "^8.3.5"
+      }
+    },
     "node_modules/postcss-media-query-parser": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz",
@@ -3538,6 +3552,28 @@
       },
       "peerDependencies": {
         "postcss": "^8.3.3"
+      }
+    },
+    "node_modules/postcss-scss": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.6.tgz",
+      "integrity": "sha512-rLDPhJY4z/i4nVFZ27j9GqLxj1pwxE80eAzUNRMXtcpipFYIeowerzBgG3yJhMtObGEXidtIgbUpQ3eLDsf5OQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss-scss"
+        }
+      ],
+      "engines": {
+        "node": ">=12.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.19"
       }
     },
     "node_modules/postcss-selector-parser": {
@@ -7267,6 +7303,13 @@
         }
       }
     },
+    "postcss-less": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-less/-/postcss-less-6.0.0.tgz",
+      "integrity": "sha512-FPX16mQLyEjLzEuuJtxA8X3ejDLNGGEG503d2YGZR5Ask1SpDN8KmZUMpzCvyalWRywAn1n1VOA5dcqfCLo5rg==",
+      "dev": true,
+      "requires": {}
+    },
     "postcss-media-query-parser": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz",
@@ -7283,6 +7326,13 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-6.0.0.tgz",
       "integrity": "sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==",
+      "dev": true,
+      "requires": {}
+    },
+    "postcss-scss": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.6.tgz",
+      "integrity": "sha512-rLDPhJY4z/i4nVFZ27j9GqLxj1pwxE80eAzUNRMXtcpipFYIeowerzBgG3yJhMtObGEXidtIgbUpQ3eLDsf5OQ==",
       "dev": true,
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -45,6 +45,8 @@
     "mocha": "^10.2.0",
     "nyc": "^15.1.0",
     "postcss": "^8.4.20",
+    "postcss-less": "^6.0.0",
+    "postcss-scss": "^4.0.6",
     "prettier": "^2.8.1",
     "rimraf": "^3.0.2",
     "stylelint": "^14.16.0",

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -61,9 +61,10 @@ function parseStyles(
     };
 
     let root: Root;
+    const parser: Parser<Document | Root> = options.parser ?? parseCSS;
 
     try {
-      root = parseCSS(extractedStylesheet.source, {
+      root = parser(extractedStylesheet.source, {
         ...postcssOptions,
         map: false
       }) as Root;

--- a/src/stringify.ts
+++ b/src/stringify.ts
@@ -8,108 +8,121 @@ import {
 import Stringifier from 'postcss/lib/stringifier';
 import {ExtractedStylesheet, SyntaxOptions} from './types.js';
 
+interface IJavaScriptStringifier {
+  new (builder: Builder, options: SyntaxOptions): Stringifier;
+}
+
 /**
  * Stringifies PostCSS nodes while taking interpolated expressions
  * into account.
+ *
+ * @param {object} cls Base class
+ * @return {object}
  */
-class JavaScriptStringifier extends Stringifier {
-  protected _parseOptions: SyntaxOptions;
+function createStringifierClass(
+  cls: typeof Stringifier
+): IJavaScriptStringifier {
+  return class JavaScriptStringifier extends cls {
+    protected _parseOptions: SyntaxOptions;
 
-  /** @inheritdoc */
-  public constructor(builder: Builder, options: SyntaxOptions) {
-    const wrappedBuilder: Builder = (
-      str: string,
-      node?: AnyNode,
-      type?: 'start' | 'end'
-    ): void => {
-      // We purposely ignore the root node since the only thing we should
-      // be stringifying here is already JS (before/after raws) so likely
-      // already contains backticks on purpose.
-      //
-      // Similarly, if there is no node, we're probably stringifying
-      // pure JS which never contained any CSS. Or something really weird
-      // we don't want to touch anyway.
-      //
-      // For everything else, we want to escape backticks.
-      if (!node || node?.type === 'root') {
-        builder(str, node, type);
-      } else {
-        const state = node?.root()?.raws[this._parseOptions.id] as
-          | ExtractedStylesheet
-          | undefined;
-        if (state) {
-          let processedString = str.replace(/\\/g, '\\\\').replace(/`/g, '\\`');
-
-          for (const {source, replacement} of state.replacements) {
-            processedString = processedString.replace(replacement, source);
-          }
-
-          builder(processedString, node, type);
-        } else {
+    /** @inheritdoc */
+    public constructor(builder: Builder, options: SyntaxOptions) {
+      const wrappedBuilder: Builder = (
+        str: string,
+        node?: AnyNode,
+        type?: 'start' | 'end'
+      ): void => {
+        // We purposely ignore the root node since the only thing we should
+        // be stringifying here is already JS (before/after raws) so likely
+        // already contains backticks on purpose.
+        //
+        // Similarly, if there is no node, we're probably stringifying
+        // pure JS which never contained any CSS. Or something really weird
+        // we don't want to touch anyway.
+        //
+        // For everything else, we want to escape backticks.
+        if (!node || node?.type === 'root') {
           builder(str, node, type);
+        } else {
+          const state = node?.root()?.raws[this._parseOptions.id] as
+            | ExtractedStylesheet
+            | undefined;
+          if (state) {
+            let processedString = str
+              .replace(/\\/g, '\\\\')
+              .replace(/`/g, '\\`');
+
+            for (const {source, replacement} of state.replacements) {
+              processedString = processedString.replace(replacement, source);
+            }
+
+            builder(processedString, node, type);
+          } else {
+            builder(str, node, type);
+          }
         }
+      };
+      super(wrappedBuilder);
+      this._parseOptions = options;
+    }
+
+    /** @inheritdoc */
+    public override document(node: Document): void {
+      if (node.nodes.length === 0) {
+        this.builder(node.source?.input.css ?? '');
+      } else {
+        super.document(node);
       }
-    };
-    super(wrappedBuilder);
-    this._parseOptions = options;
-  }
-
-  /** @inheritdoc */
-  public override document(node: Document): void {
-    if (node.nodes.length === 0) {
-      this.builder(node.source?.input.css ?? '');
-    } else {
-      super.document(node);
-    }
-  }
-
-  /** @inheritdoc */
-  public override root(node: Root): void {
-    this.builder(node.raws.codeBefore ?? '', node, 'start');
-
-    this.body(node);
-
-    // Here we want to recover any previously removed JS indentation
-    // if possible. Otherwise, we use the `after` string as-is.
-    const afterKey = `${this._parseOptions.id}:after`;
-    const after = node.raws[afterKey] ?? node.raws.after;
-    if (after) {
-      this.builder(after);
     }
 
-    this.builder(node.raws.codeAfter ?? '', node, 'end');
-  }
+    /** @inheritdoc */
+    public override root(node: Root): void {
+      this.builder(node.raws.codeBefore ?? '', node, 'start');
 
-  /** @inheritdoc */
-  public override raw(
-    node: AnyNode,
-    own: string,
-    detect: string | undefined
-  ): string {
-    const beforeKey = `${this._parseOptions.id}:before`;
-    const afterKey = `${this._parseOptions.id}:after`;
-    const betweenKey = `${this._parseOptions.id}:between`;
-    if (own === 'before' && node.raws['before'] && node.raws[beforeKey]) {
-      return node.raws[beforeKey];
-    }
-    if (own === 'after' && node.raws['after'] && node.raws[afterKey]) {
-      return node.raws[afterKey];
-    }
-    if (own === 'between' && node.raws['between'] && node.raws[betweenKey]) {
-      return node.raws[betweenKey];
-    }
-    return super.raw(node, own, detect);
-  }
+      this.body(node);
 
-  /** @inheritdoc */
-  public override rawValue(node: AnyNode, prop: string): string {
-    const rawKey = `${this._parseOptions.id}:${prop}`;
-    if (Object.prototype.hasOwnProperty.call(node.raws, rawKey)) {
-      return `${node.raws[rawKey]}`;
+      // Here we want to recover any previously removed JS indentation
+      // if possible. Otherwise, we use the `after` string as-is.
+      const afterKey = `${this._parseOptions.id}:after`;
+      const after = node.raws[afterKey] ?? node.raws.after;
+      if (after) {
+        this.builder(after);
+      }
+
+      this.builder(node.raws.codeAfter ?? '', node, 'end');
     }
 
-    return super.rawValue(node, prop);
-  }
+    /** @inheritdoc */
+    public override raw(
+      node: AnyNode,
+      own: string,
+      detect: string | undefined
+    ): string {
+      const beforeKey = `${this._parseOptions.id}:before`;
+      const afterKey = `${this._parseOptions.id}:after`;
+      const betweenKey = `${this._parseOptions.id}:between`;
+      if (own === 'before' && node.raws['before'] && node.raws[beforeKey]) {
+        return node.raws[beforeKey];
+      }
+      if (own === 'after' && node.raws['after'] && node.raws[afterKey]) {
+        return node.raws[afterKey];
+      }
+      if (own === 'between' && node.raws['between'] && node.raws[betweenKey]) {
+        return node.raws[betweenKey];
+      }
+      return super.raw(node, own, detect);
+    }
+
+    /** @inheritdoc */
+    public override rawValue(node: AnyNode, prop: string): string {
+      const rawKey = `${this._parseOptions.id}:${prop}`;
+      if (Object.prototype.hasOwnProperty.call(node.raws, rawKey)) {
+        return `${node.raws[rawKey]}`;
+      }
+
+      return super.rawValue(node, prop);
+    }
+  };
 }
 
 /**
@@ -118,8 +131,11 @@ class JavaScriptStringifier extends Stringifier {
  * @return {StringifyFn}
  */
 export function createStringifier(options: SyntaxOptions): StringifierFn {
+  const cls = createStringifierClass(options.stringifier ?? Stringifier);
+
   return (node: AnyNode, builder: Builder): void => {
-    const str = new JavaScriptStringifier(builder, options);
+    // eslint-disable-next-line new-cap
+    const str = new cls(builder, options);
     str.stringify(node);
   };
 }

--- a/src/test/parse_test.ts
+++ b/src/test/parse_test.ts
@@ -3,10 +3,8 @@ import {createParser} from '../parse.js';
 import {assert} from 'chai';
 import {ExtractedStylesheet} from '../types.js';
 import {Root, Document, Declaration} from 'postcss';
-import less = require('postcss-less');
+import {parse as lessParser} from 'postcss-less';
 import {parse as scssParser} from 'postcss-scss';
-
-const {parse: lessParser} = less;
 
 describe('parse', () => {
   afterEach(() => {

--- a/src/test/stringify_test.ts
+++ b/src/test/stringify_test.ts
@@ -3,11 +3,9 @@ import {assert} from 'chai';
 import {createParser} from '../parse.js';
 import {Parser, Root, Document, Stringifier, Rule, Declaration} from 'postcss';
 import lessStringifier = require('postcss-less/lib/LessStringifier.js');
-import less = require('postcss-less');
+import {parse as lessParser} from 'postcss-less';
 import {parse as scssParser} from 'postcss-scss';
 import scssStringifier = require('postcss-scss/lib/scss-stringifier');
-
-const {parse: lessParser} = less;
 
 describe('createStringifier', () => {
   let parse: Parser<Root | Document>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,10 @@
 import {ParserOptions as BabelParserOptions} from '@babel/parser';
+import {Parser, Document, Root, Builder} from 'postcss';
+import Stringifier from 'postcss/lib/stringifier.js';
+
+interface StringifierConstructor {
+  new (builder: Builder): Stringifier;
+}
 
 export type PlaceholderFunc = (
   key: number,
@@ -11,6 +17,8 @@ export interface SyntaxOptions {
   tagNames?: string[];
   babelOptions?: BabelParserOptions;
   placeholder?: PlaceholderFunc;
+  parser?: Parser<Document | Root>;
+  stringifier?: StringifierConstructor;
 }
 
 export interface ExpressionReplacement {

--- a/src/types/postcss-less.d.ts
+++ b/src/types/postcss-less.d.ts
@@ -1,0 +1,15 @@
+declare module 'postcss-less' {
+  import {Syntax} from 'postcss';
+
+  const syntax: Syntax;
+
+  export = syntax;
+}
+
+declare module 'postcss-less/lib/LessStringifier.js' {
+  import Stringifier from 'postcss/lib/stringifier.js';
+
+  const stringifier: typeof Stringifier;
+
+  export = stringifier;
+}

--- a/src/types/postcss-scss.d.ts
+++ b/src/types/postcss-scss.d.ts
@@ -1,0 +1,7 @@
+declare module 'postcss-scss/lib/scss-stringifier' {
+  import Stringifier from 'postcss/lib/stringifier.js';
+
+  const stringifier: typeof Stringifier;
+
+  export = stringifier;
+}


### PR DESCRIPTION
Fixes #1 

This makes it possible to pass something like the LESS parser/stringifier in to use as a base instead of postcss' default parser/stringifier.

e.g.

```ts
createParser({
  // ...
  parser: require('postcss-scss').parse,
  stringifier: require('postcss-scss/lib/scss-stringifier.js')
});
```

unfortunately, we can't just use `syntax.stringify` as we need to override parts of the `Stringifier` that uses internally. so instead, we require that you pass the class, _not_ the factory function.

ultimately, this should be exposed **by each individual syntax**, e.g. `postcss-lit/scss` (which individually sets the code above up)

cc @ai in case you were curious