### PR TITLE
feat: support nested templates

### DIFF
--- a/src/esUtils.ts
+++ b/src/esUtils.ts
@@ -1,0 +1,20 @@
+import {Node} from '@babel/types';
+import {NodePath} from '@babel/traverse';
+
+/**
+ * Determines if a given ES node contains a particular child
+ * @param {NodePath<Node>} node Container node
+ * @param {NodePath<Node>} child Child to look for
+ * @return {boolean}
+ */
+export function nodeContainsChild(
+  node: NodePath<Node>,
+  child: NodePath<Node>
+): boolean {
+  return (
+    node.node.range !== undefined &&
+    child.node.range !== undefined &&
+    node.node.range[0] < child.node.range[0] &&
+    node.node.range[1] > child.node.range[1]
+  );
+}

--- a/src/placeholders.ts
+++ b/src/placeholders.ts
@@ -62,6 +62,12 @@ export function computePossiblePosition(
 ): Position {
   let possiblyInComment = false;
   let possiblePosition: Position = 'default';
+
+  // Special case for top level interpolation
+  if (prefix.trim().length === 0) {
+    return 'block';
+  }
+
   for (let i = prefix.length; i > 0; i--) {
     const chr = prefix[i];
     if (possiblyInComment) {
@@ -173,7 +179,7 @@ export function createPlaceholderFunc(
       return value;
     }
 
-    if (!before) {
+    if (before === undefined) {
       return defaultPlaceholder(i, syntax.id);
     }
 

--- a/src/stringify.ts
+++ b/src/stringify.ts
@@ -77,6 +77,14 @@ function createStringifierClass(
 
     /** @inheritdoc */
     public override root(node: Root): void {
+      const raws = node.raws[this._parseOptions.id] as
+        | ExtractedStylesheet
+        | undefined;
+
+      if (raws && raws.isNested) {
+        return;
+      }
+
       this.builder(node.raws.codeBefore ?? '', node, 'start');
 
       this.body(node);

--- a/src/test/parse_test.ts
+++ b/src/test/parse_test.ts
@@ -18,6 +18,24 @@ describe('parse', () => {
       assert.equal(doc.nodes.length, 0);
     });
 
+    it('should support nested templates', () => {
+      const parse = createParser({id: 'foo', tagNames: ['css']});
+      const doc = parse(`
+        css\`
+          $\{css\`
+            color: hotpink;
+          \`}
+          color: blue;
+        \`;
+      `);
+      const root0 = doc.nodes[0] as Root;
+      const root1 = doc.nodes[1] as Root;
+
+      assert.equal(doc.nodes.length, 2);
+      assert.equal(root0.nodes.length, 2);
+      assert.equal(root1.nodes.length, 1);
+    });
+
     it('should skip and log invalid templates', () => {
       const stub = hanbi.stubMethod(console, 'warn');
       const parse = createParser({id: 'foo', tagNames: ['css']});

--- a/src/test/placeholders_test.ts
+++ b/src/test/placeholders_test.ts
@@ -30,9 +30,9 @@ function getNodePathsFromTemplate(source: string): Array<NodePath<Node>> {
 
 describe('placeholders', () => {
   describe('computePossiblePosition', () => {
-    it('should use default when empty', () => {
+    it('should use block when empty', () => {
       const result = computePossiblePosition('');
-      assert.equal(result, 'default');
+      assert.equal(result, 'block');
     });
 
     it('should be statement if semi-colon encountered', () => {
@@ -150,6 +150,11 @@ describe('placeholders', () => {
       `);
       const result = createPlaceholder(808, nodes[0]!);
       assert.equal(result, 'whatever');
+    });
+
+    it('should use block placeholder if empty prefix', () => {
+      const result = createPlaceholder(808, nodes[0]!, '');
+      assert.equal(result, '/* POSTCSS_foo_808 */');
     });
 
     describe('default positions', () => {

--- a/src/test/stringify_test.ts
+++ b/src/test/stringify_test.ts
@@ -638,4 +638,19 @@ describe('createStringifier', () => {
     `
     );
   });
+
+  it('should stringify nested templates', () => {
+    const source = `
+      css\`
+        $\{css\`
+          color: hotpink;
+        \`}
+        color: blue;
+      \`;
+    `;
+
+    const ast = parse(source);
+    const output = ast.toString({stringify});
+    assert.equal(output, source);
+  });
 });

--- a/src/test/stylelint_test.ts
+++ b/src/test/stylelint_test.ts
@@ -142,6 +142,42 @@ describe('stylelint', () => {
     );
   });
 
+  it('should be fixable by stylelint with nested templates', async () => {
+    const source = `
+      css\`
+        $\{css\`
+          color: hotpink;;
+        \`};
+
+        color: blue;
+      \`;
+    `;
+    const result = await stylelint.lint({
+      customSyntax: {parse, stringify},
+      code: source,
+      codeFilename: 'foo.js',
+      fix: true,
+      config: {
+        rules: {
+          'no-extra-semicolons': true
+        }
+      }
+    });
+
+    assert.equal(
+      result.output,
+      `
+      css\`
+        $\{css\`
+          color: hotpink;
+        \`};
+
+        color: blue;
+      \`;
+    `
+    );
+  });
+
   it('should be compatible with indentation rule', async () => {
     const source = `
       css\`

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,4 +37,5 @@ export interface ExtractedStylesheet {
     offset: number;
   };
   indentationMap: Map<number, number>;
+  isNested: boolean;
 }


### PR DESCRIPTION
This adds support for nested templates since some syntaxes support that.

This also includes a fix to the placeholder strategy such that prefix-less expressions now have a comment placeholder rather than the default (i.e. are considered block-level).

**DRAFT** because once i add a test for nested templates passing through stylelint, that test _should_ fail. we still have some fixing up to do here so that'll work as expected.