### PR TITLE
feat: support a wider range of expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ as follows:
 
   // Custom sub-stringifier _class_
   stringifier: require('postcss-less/lib/LessStringifier.js')
+
+  // Custom babel options for when parsing source JS
+  babelOptions: { ... },
+
+  // Custom function for generating placeholders for expressions
+  placeholder: customPlaceholderFn
 }
 ```
 

--- a/src/extract.ts
+++ b/src/extract.ts
@@ -36,8 +36,8 @@ function isSupportedTag(tag: string, supported: string[]): boolean {
 export function extractTemplatesFromSource(
   source: string,
   options: SyntaxOptions
-): Set<TaggedTemplateExpression> {
-  const extractedStyles = new Set<TaggedTemplateExpression>();
+): Set<NodePath<TaggedTemplateExpression>> {
+  const extractedStyles = new Set<NodePath<TaggedTemplateExpression>>();
   const tagNames = options?.tagNames;
 
   // Return early if there's no tag names to look for
@@ -60,14 +60,15 @@ export function extractTemplatesFromSource(
     TaggedTemplateExpression: (
       path: NodePath<TaggedTemplateExpression>
     ): void => {
-      if (path.node.tag.start !== null && path.node.tag.end !== null) {
-        const tag = source.slice(path.node.tag.start, path.node.tag.end);
+      const tagNode = path.get('tag');
+      if (tagNode.node.start !== null && tagNode.node.end !== null) {
+        const tag = tagNode.toString();
 
         if (
           isSupportedTag(tag, tagNames) &&
           !hasDisableComment(path, options)
         ) {
-          extractedStyles.add(path.node);
+          extractedStyles.add(path);
         }
       }
     }

--- a/src/normalise.ts
+++ b/src/normalise.ts
@@ -1,4 +1,5 @@
 import {TaggedTemplateExpression} from '@babel/types';
+import {NodePath} from '@babel/traverse';
 
 export interface NormalisedSourceResult {
   result: string;
@@ -12,12 +13,12 @@ export interface NormalisedSourceResult {
 /**
  * Computes the normalised source (whitespace, padding, etc)
  * @param {string} source Original source
- * @param {TaggedTemplateExpression} node Source node
+ * @param {NodePath<TaggedTemplateExpression>} node Source node
  * @return {IndentationMapResult}
  */
 export function computeNormalisedSource(
   source: string,
-  node: TaggedTemplateExpression
+  node: NodePath<TaggedTemplateExpression>
 ): NormalisedSourceResult {
   const result: NormalisedSourceResult = {
     result: '',
@@ -27,7 +28,8 @@ export function computeNormalisedSource(
       offset: 0
     }
   };
-  const baseIndentation = (node.quasi.loc?.end.column ?? 1) - 1;
+  const quasi = node.get('quasi');
+  const baseIndentation = (quasi.node.loc?.end.column ?? 1) - 1;
   const sourceLines = source.split('\n');
   const indentationPattern = new RegExp(`^[ \\t]{${baseIndentation}}`);
   const emptyLinePattern = /^[ \t\r]*$/;

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -35,22 +35,24 @@ function parseStyles(
   const doc = new Document();
   let currentOffset = 0;
 
-  for (const node of extractedStyles) {
-    if (!node.quasi.range) {
+  for (const path of extractedStyles) {
+    const quasi = path.get('quasi');
+
+    if (!quasi.node.range) {
       continue;
     }
 
-    const startIndex = node.quasi.range[0] + 1;
+    const startIndex = quasi.node.range[0] + 1;
 
     const replacedSource = computeReplacedSource(
       source,
-      node,
+      path,
       computePlaceholder
     );
 
     const normalisedSource = computeNormalisedSource(
       replacedSource.result,
-      node
+      path
     );
 
     const extractedStylesheet: ExtractedStylesheet = {
@@ -71,7 +73,7 @@ function parseStyles(
     } catch (err) {
       if (err instanceof CssSyntaxError) {
         const file = postcssOptions?.from ?? 'unknown';
-        const line = node.loc?.start.line ?? 'unknown';
+        const line = path.node.loc?.start.line ?? 'unknown';
 
         console.warn(
           `[postcss (${options.id})]`,
@@ -107,12 +109,12 @@ function parseStyles(
     // it could just access root.parent to get the document...
     (root as Root & {document: Document}).document = doc;
 
-    const walker = locationCorrectionWalker(node, options);
+    const walker = locationCorrectionWalker(path, options);
     walker(root);
     root.walk(walker);
     doc.nodes.push(root);
 
-    currentOffset = node.quasi.range[1] - 1;
+    currentOffset = quasi.node.range[1] - 1;
   }
 
   if (doc.nodes.length > 0) {

--- a/src/placeholders.ts
+++ b/src/placeholders.ts
@@ -1,3 +1,5 @@
+import {NodePath} from '@babel/traverse';
+import {Node} from '@babel/types';
 import {PlaceholderFunc, SyntaxOptions} from './types.js';
 
 export type Position =
@@ -119,12 +121,33 @@ export function computePossiblePosition(
 }
 
 /**
+ * Tries to evaluate an AST node into a string value
+ * @param {NodePath<Node>} node Node to evaluate
+ * @return {string|undefined}
+ */
+function tryEvaluateNode(node: NodePath<Node>): string | undefined {
+  const val = node.evaluate();
+
+  if (val.confident) {
+    return val.value;
+  }
+
+  return undefined;
+}
+
+/**
  * Computes the placeholder for an expression
  * @param {SyntaxOptions} options Syntax options
  * @return {PlaceholderFunc}
  */
 export function createPlaceholderFunc(options: SyntaxOptions): PlaceholderFunc {
-  return (i, before, after) => {
+  return (i, node, before, after) => {
+    const value = tryEvaluateNode(node);
+
+    if (value !== undefined) {
+      return value;
+    }
+
     if (!before) {
       return defaultPlaceholder(i, options.id);
     }

--- a/src/replacements.ts
+++ b/src/replacements.ts
@@ -10,7 +10,7 @@ export interface SourceReplacementResult {
 /**
  * Computes the source with all expressions replaced
  * @param {string} source Original source text
- * @param {TaggedTemplateExpression} node Node to traverse
+ * @param {NodePath<TaggedTemplateExpression>} node Node to traverse
  * @param {Function} computePlaceholder Function used to compute the
  * placeholder for a given expression
  * @return {SourceReplacement}

--- a/src/test/normalise_test.ts
+++ b/src/test/normalise_test.ts
@@ -1,12 +1,13 @@
 import {assert} from 'chai';
 import {TaggedTemplateExpression} from '@babel/types';
+import {NodePath} from '@babel/traverse';
 import {computeNormalisedSource} from '../normalise.js';
 import {extractTemplatesFromSource} from '../extract.js';
 import {computeReplacedSource} from '../replacements.js';
 
 const computeNodeAndSource = (
   source: string
-): [string, TaggedTemplateExpression] => {
+): [string, NodePath<TaggedTemplateExpression>] => {
   const templates = extractTemplatesFromSource(source, {
     id: 'foo',
     tagNames: ['css']

--- a/src/test/placeholders_test.ts
+++ b/src/test/placeholders_test.ts
@@ -123,6 +123,35 @@ describe('placeholders', () => {
       assert.equal(result, 'pink');
     });
 
+    it('should resolve one side of a simple conditional', () => {
+      nodes = getNodePathsFromTemplate(`
+        css\`
+          $\{unknownValue ? otherUnknown : 'b'};
+        \`;
+      `);
+      const result = createPlaceholder(808, nodes[0]!);
+      assert.equal(result, 'b');
+    });
+
+    it('should accept a custom evaluator', () => {
+      createPlaceholder = createPlaceholderFunc(
+        {
+          id: 'foo'
+        },
+        {
+          evaluator: () => 'whatever'
+        }
+      );
+
+      nodes = getNodePathsFromTemplate(`
+        css\`
+          $\{someConstant};
+        \`;
+      `);
+      const result = createPlaceholder(808, nodes[0]!);
+      assert.equal(result, 'whatever');
+    });
+
     describe('default positions', () => {
       it('should use default placeholder', () => {
         const result = createPlaceholder(808, nodes[0]!, '/* some comment */');

--- a/src/test/placeholders_test.ts
+++ b/src/test/placeholders_test.ts
@@ -1,9 +1,32 @@
+import {Node, TaggedTemplateExpression} from '@babel/types';
+import {default as traverse, NodePath} from '@babel/traverse';
+import {parseScript} from './util.js';
 import {
   createPlaceholderFunc,
   computePossiblePosition
 } from '../placeholders.js';
 import {PlaceholderFunc} from '../types.js';
 import {assert} from 'chai';
+
+/**
+ * Gets the NodePaths for a given source template
+ * @param {string} source Source code
+ * @return {Array<NodePath<Expression>>}
+ */
+function getNodePathsFromTemplate(source: string): Array<NodePath<Node>> {
+  const ast = parseScript(source);
+  const results: Array<NodePath<Node>> = [];
+
+  traverse(ast, {
+    TaggedTemplateExpression: (node: NodePath<TaggedTemplateExpression>) => {
+      for (const expr of node.get('quasi').get('expressions')) {
+        results.push(expr);
+      }
+    }
+  });
+
+  return results;
+}
 
 describe('placeholders', () => {
   describe('computePossiblePosition', () => {
@@ -70,21 +93,39 @@ describe('placeholders', () => {
 
   describe('createPlaceholder', () => {
     let createPlaceholder: PlaceholderFunc;
+    let nodes: Array<NodePath<Node>>;
 
     beforeEach(() => {
+      nodes = getNodePathsFromTemplate(`
+        css\`
+          $\{a & b}
+        \`;
+      `);
       createPlaceholder = createPlaceholderFunc({
         id: 'foo'
       });
     });
 
     it('should use default placeholder if no prefix', () => {
-      const result = createPlaceholder(808);
+      const result = createPlaceholder(808, nodes[0]!);
       assert.equal(result, 'POSTCSS_foo_808');
+    });
+
+    it('should resolve expressions which can be confidently evaluated', () => {
+      nodes = getNodePathsFromTemplate(`
+        const foo = 'pink';
+        const bar = foo || 'blue';
+        css\`
+          $\{bar};
+        \`;
+      `);
+      const result = createPlaceholder(808, nodes[0]!);
+      assert.equal(result, 'pink');
     });
 
     describe('default positions', () => {
       it('should use default placeholder', () => {
-        const result = createPlaceholder(808, '/* some comment */');
+        const result = createPlaceholder(808, nodes[0]!, '/* some comment */');
 
         assert.equal(result, 'POSTCSS_foo_808');
       });
@@ -92,7 +133,7 @@ describe('placeholders', () => {
 
     describe('selector positions', () => {
       it('should use default placeholder', () => {
-        const result = createPlaceholder(808, '.foo {}', ' {}');
+        const result = createPlaceholder(808, nodes[0]!, '.foo {}', ' {}');
 
         assert.equal(result, 'POSTCSS_foo_808');
       });
@@ -100,7 +141,7 @@ describe('placeholders', () => {
 
     describe('comment positions', () => {
       it('should use default placeholder', () => {
-        const result = createPlaceholder(808, '/* foo ', ' bar */');
+        const result = createPlaceholder(808, nodes[0]!, '/* foo ', ' bar */');
 
         assert.equal(result, 'POSTCSS_foo_808');
       });
@@ -108,7 +149,7 @@ describe('placeholders', () => {
 
     describe('statement positions', () => {
       it('should use a comment placeholder', () => {
-        const result = createPlaceholder(808, 'color: hotpink;');
+        const result = createPlaceholder(808, nodes[0]!, 'color: hotpink;');
 
         assert.equal(result, '/* POSTCSS_foo_808 */');
       });
@@ -116,7 +157,7 @@ describe('placeholders', () => {
 
     describe('block positions', () => {
       it('should use a comment placeholder', () => {
-        const result = createPlaceholder(808, '.foo { }');
+        const result = createPlaceholder(808, nodes[0]!, '.foo { }');
 
         assert.equal(result, '/* POSTCSS_foo_808 */');
       });
@@ -124,7 +165,12 @@ describe('placeholders', () => {
 
     describe('property positions', () => {
       it('should use a variable placeholder', () => {
-        const result = createPlaceholder(808, '.foo { ', ': hotpink; }');
+        const result = createPlaceholder(
+          808,
+          nodes[0]!,
+          '.foo { ',
+          ': hotpink; }'
+        );
 
         assert.equal(result, '--POSTCSS_foo_808');
       });

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,6 @@
 import {ParserOptions as BabelParserOptions} from '@babel/parser';
+import {Node} from '@babel/types';
+import {NodePath} from '@babel/traverse';
 import {Parser, Document, Root, Builder} from 'postcss';
 import Stringifier from 'postcss/lib/stringifier.js';
 
@@ -8,6 +10,7 @@ interface StringifierConstructor {
 
 export type PlaceholderFunc = (
   key: number,
+  node: NodePath<Node>,
   before?: string,
   after?: string
 ) => string;


### PR DESCRIPTION
cc @dermeck

this isn't finished yet, but once its done it should mean many more expressions are supported.

it infers values where possible now:

```ts
const someVar = 'hotpink';

css`
  color: ${someVar};
`;
```

the above will infer the actual value of `someVar` rather than guessing.

ill also add some knowledge about styled-components (or make it configurable enough that we can specify that). such that interpolated functions have their return values inferred:

```ts
css`
  color: ${(props) => props.x ? 'pink' : 'red'};
`;
```

once thats done ill merge this and update the styled-components syntax